### PR TITLE
ルーティング機能をreact-router-domにより追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4563,6 +4563,18 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
     },
+    "history": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
+      "integrity": "sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==",
+      "requires": {
+        "invariant": "2.2.2",
+        "loose-envify": "1.3.1",
+        "resolve-pathname": "2.2.0",
+        "value-equal": "0.4.0",
+        "warning": "3.0.0"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -8448,6 +8460,33 @@
         "prop-types": "15.6.0"
       }
     },
+    "react-router": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.2.0.tgz",
+      "integrity": "sha512-DY6pjwRhdARE4TDw7XjxjZsbx9lKmIcyZoZ+SDO7SBJ1KUeWNxT22Kara2AC7u6/c2SYEHlEDLnzBCcNhLE8Vg==",
+      "requires": {
+        "history": "4.7.2",
+        "hoist-non-react-statics": "2.3.1",
+        "invariant": "2.2.2",
+        "loose-envify": "1.3.1",
+        "path-to-regexp": "1.7.0",
+        "prop-types": "15.6.0",
+        "warning": "3.0.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.2.2.tgz",
+      "integrity": "sha512-cHMFC1ZoLDfEaMFoKTjN7fry/oczMgRt5BKfMAkTu5zEuJvUiPp1J8d0eXSVTnBh6pxlbdqDhozunOOLtmKfPA==",
+      "requires": {
+        "history": "4.7.2",
+        "invariant": "2.2.2",
+        "loose-envify": "1.3.1",
+        "prop-types": "15.6.0",
+        "react-router": "4.2.0",
+        "warning": "3.0.0"
+      }
+    },
     "react-scripts": {
       "version": "1.0.14",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-1.0.14.tgz",
@@ -8867,6 +8906,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
       "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+    },
+    "resolve-pathname": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
+      "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg=="
     },
     "restore-cursor": {
       "version": "2.0.0",
@@ -9881,6 +9925,11 @@
         "spdx-correct": "1.0.2",
         "spdx-expression-parse": "1.0.4"
       }
+    },
+    "value-equal": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
+      "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "material-ui": "^1.0.0-beta.21",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
+    "react-router-dom": "^4.2.2",
     "react-scripts": "1.0.14"
   },
   "scripts": {

--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,20 @@
-import React, { Component } from 'react';
 import './App.css';
+
+import { BrowserRouter, Route, Switch } from 'react-router-dom';
+import React, { Component } from 'react';
+
 import Register from './Register';
+import NoMatch from './NoMatch';
 
 class App extends Component {
   render() {
     return (
-      <Register/>
+      <BrowserRouter>
+        <Switch>
+          <Route exact path="/" component={Register} />
+          <Route component={NoMatch} />
+        </Switch>
+      </BrowserRouter>
     );
   }
 }

--- a/src/NoMatch.js
+++ b/src/NoMatch.js
@@ -1,0 +1,36 @@
+import { Grid, Paper, Typography } from 'material-ui';
+import React, {Component} from 'react';
+import {PAGE_NOT_FOUND} from './const/const-values';
+
+const styles = {
+  paper: {
+    paddingTop: 16,
+    paddingBottom: 16
+  },
+  title: {
+    padding: 12,
+  },
+  body: {
+    padding: 8
+  }
+}
+
+class NoMatch extends Component {
+  render = () => (
+    
+    <Grid container spacing={24} justify="center" style={styles.paper}>
+      <Grid item>
+        <Paper>
+          <Typography type="title" style={styles.title}>
+            Page Not Found
+          </Typography>
+          <Typography type="body1" style={styles.body}>
+            {PAGE_NOT_FOUND}
+          </Typography>
+        </Paper>
+      </Grid>
+    </Grid>
+  );
+}
+
+export default NoMatch;

--- a/src/NoMatch.js
+++ b/src/NoMatch.js
@@ -1,5 +1,5 @@
 import { Grid, Paper, Typography } from 'material-ui';
-import React, {Component} from 'react';
+import React from 'react';
 import {PAGE_NOT_FOUND} from './const/const-values';
 
 const styles = {

--- a/src/NoMatch.js
+++ b/src/NoMatch.js
@@ -15,9 +15,8 @@ const styles = {
   }
 }
 
-class NoMatch extends Component {
-  render = () => (
-    
+const NoMatch = (props) => {
+  return (
     <Grid container spacing={24} justify="center" style={styles.paper}>
       <Grid item>
         <Paper>

--- a/src/const/const-values.js
+++ b/src/const/const-values.js
@@ -3,6 +3,7 @@ export const CHECKOUT = `お会計`;
 export const DEPOSIT = `お預り金`;
 export const EVENTS_URI = `/events/`;
 export const MINUS = `-`;
+export const PAGE_NOT_FOUND = `お探しのページは見つかりませんでした。`;
 export const PAYMENT = `お支払`;
 export const PLUS = `+`;
 export const SUBTOTAL = `小計`;


### PR DESCRIPTION
- ルーティングはSwitchにより排他的とし、マッチしない場合はNoMatchコンポーネントを描画する。
- とりあえずはルートパスでRegisterを描画、それ以外はNoMatch