### PR TITLE
環境変数NODE_ENVを参照して環境ごとにconst-valuesの値を設定するように修正, fixed #10

### DIFF
--- a/src/Register.js
+++ b/src/Register.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 import PaymentButton from './PaymentButton.js';
 import EventItemsList from './EventItemsList.js';
 import PaymentDialog from './PaymentDialog';
-import { BASE_URI, EVENTS_URI } from './const/const-values';
+import { BASE_URI, EVENTS_URI } from './const/urls';
 
 class Register extends Component {
   constructor(props) {

--- a/src/Register.js
+++ b/src/Register.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 import PaymentButton from './PaymentButton.js';
 import EventItemsList from './EventItemsList.js';
 import PaymentDialog from './PaymentDialog';
-import { EVENTS_URI } from './const/const-values';
+import { BASE_URI, EVENTS_URI } from './const/const-values';
 
 class Register extends Component {
   constructor(props) {
@@ -27,7 +27,7 @@ class Register extends Component {
 
   handleEventIdChange = event => {
     const newEventId = event.target.value;
-    const getUrl = `${EVENTS_URI}${newEventId}`;
+    const getUrl = `${BASE_URI}${EVENTS_URI}${newEventId}`;
 
     if (Number.isNaN(parseInt(newEventId, 10))) return;
 

--- a/src/const/const-values.js
+++ b/src/const/const-values.js
@@ -1,7 +1,33 @@
+function switchByEnv(values) {
+  let defaultValue = undefined;
+  if (values.default) {
+    defaultValue = values.default;
+  }
+  if (process.env.NODE_ENV === "development") {
+    return values.development || defaultValue;
+  }
+  switch (process.env.NODE_ENV) {
+    case "development":
+      return values.development || defaultValue;
+      break;
+    case "test":
+      return values.test || defaultValue;
+      break;
+    case "production":
+      return values.production || defaultValue;
+      break;
+    default:
+      return defaultValue;
+  }
+}
+console.log(process.env.NODE_ENV);
 export const BACK = `戻る`;
 export const CHECKOUT = `お会計`;
 export const DEPOSIT = `お預り金`;
-export const EVENTS_URI = `/events/`;
+export const EVENTS_URI = switchByEnv({
+  default: `http://localhost:3001/events/`,
+  production: `/events`,
+});
 export const MINUS = `-`;
 export const PAYMENT = `お支払`;
 export const PLUS = `+`;

--- a/src/const/const-values.js
+++ b/src/const/const-values.js
@@ -1,31 +1,6 @@
-function switchByEnv(values) {
-  let defaultValue = undefined;
-  if (values.default) {
-    defaultValue = values.default;
-  }
-  if (process.env.NODE_ENV === "development") {
-    return values.development || defaultValue;
-  }
-  switch (process.env.NODE_ENV) {
-    case "development":
-      return values.development || defaultValue;
-    case "test":
-      return values.test || defaultValue;
-    case "production":
-      return values.production || defaultValue;
-    default:
-      return defaultValue;
-  }
-}
-
 export const BACK = `戻る`;
-export const BASE_URI = switchByEnv({
-  default: `http://localhost:3001`,
-  production: ``,
-});
 export const CHECKOUT = `お会計`;
 export const DEPOSIT = `お預り金`;
-export const EVENTS_URI = `/events/`;
 export const MINUS = `-`;
 export const PAYMENT = `お支払`;
 export const PLUS = `+`;

--- a/src/const/const-values.js
+++ b/src/const/const-values.js
@@ -9,25 +9,23 @@ function switchByEnv(values) {
   switch (process.env.NODE_ENV) {
     case "development":
       return values.development || defaultValue;
-      break;
     case "test":
       return values.test || defaultValue;
-      break;
     case "production":
       return values.production || defaultValue;
-      break;
     default:
       return defaultValue;
   }
 }
-console.log(process.env.NODE_ENV);
+
 export const BACK = `戻る`;
+export const BASE_URI = switchByEnv({
+  default: `http://localhost:3001`,
+  production: ``,
+});
 export const CHECKOUT = `お会計`;
 export const DEPOSIT = `お預り金`;
-export const EVENTS_URI = switchByEnv({
-  default: `http://localhost:3001/events/`,
-  production: `/events`,
-});
+export const EVENTS_URI = `/events/`;
 export const MINUS = `-`;
 export const PAYMENT = `お支払`;
 export const PLUS = `+`;

--- a/src/const/urls.js
+++ b/src/const/urls.js
@@ -1,0 +1,26 @@
+const switchByEnv = values => {
+  let defaultValue = undefined;
+  if (values.default) {
+    defaultValue = values.default;
+  }
+  if (process.env.NODE_ENV === "development") {
+    return values.development || defaultValue;
+  }
+  switch (process.env.NODE_ENV) {
+    case "development":
+      return values.development || defaultValue;
+    case "test":
+      return values.test || defaultValue;
+    case "production":
+      return values.production || defaultValue;
+    default:
+      return defaultValue;
+  }
+};
+
+export const BASE_URI = switchByEnv({
+  default: `http://localhost:3001`,
+  production: ``,
+});
+
+export const EVENTS_URI = `/events/`;


### PR DESCRIPTION
# switchByEnv

In /const/const-values.js

```
switchByEnv( {
    [development: object, ]
    [test: object, ]
    [production: object, ]
    [default: object]
} );
```

- development: development環境時に返す値 (ex. npm start)
- test: test環境時に返す値 (ex. npm run test)
- production: production環境時に返す値 (ex. npm run build && serve -s build)
- default: 上記3種以外の環境時に返す値、かつ、上記3種でセットしていない値があるとき、その環境時に返す値