### PR TITLE
event_itemsを取得する処理を修正

### DIFF
--- a/src/ItemsDashboard.js
+++ b/src/ItemsDashboard.js
@@ -35,7 +35,7 @@ class ItemsDashboard extends Component {
   }
 
   init = () => {
-    const getUrl = `${BASE_URI}${EVENTS_URI}${this.props.event_id}`;
+    const getUrl = `${BASE_URI}${EVENTS_URI}${localStorage.event_id}`;
 
     axios
       .get(getUrl)

--- a/src/ItemsDashboard.js
+++ b/src/ItemsDashboard.js
@@ -31,11 +31,16 @@ class ItemsDashboard extends Component {
         count: ''
       }
     };
-    this.init();
+    this.init(this.props.event_id);
   }
 
-  init = () => {
-    const getUrl = `${BASE_URI}${EVENTS_URI}${localStorage.event_id}`;
+  componentWillReceiveProps = nextProps => {
+    this.init(nextProps.event_id);
+  }
+
+  init = eventId => {
+    if (eventId === 0) return;
+    const getUrl = `${BASE_URI}${EVENTS_URI}${eventId}`;
 
     axios
       .get(getUrl)


### PR DESCRIPTION
event_idが適切に設定されていない時はリクエストを送らない様に変更.
(ブランチ名ミスった.)