### PR TITLE
「戻る」ボタンで1つ前の履歴に戻る機能の追加

### DIFF
--- a/src/NavigationBar.js
+++ b/src/NavigationBar.js
@@ -1,5 +1,6 @@
 import { AppBar, Button, IconButton, Toolbar, Typography } from 'material-ui';
 import MenuIcon from 'material-ui-icons/Menu';
+import GoBackIcon from 'material-ui-icons/KeyboardBackspace';
 import React from 'react';
 
 import { LOGOUT } from './const/const-values';
@@ -18,13 +19,23 @@ const NavigationBar = props => {
     <nav>
       <AppBar position="fixed" style={styles.navBar}>
         <Toolbar>
-          <IconButton
-            color="contrast"
-            aria-label="Pick a Event"
-            onClick={props.handleOpenDrawer}
-          >
-            <MenuIcon />
-          </IconButton>
+          {(props.goBack) ? (
+            <IconButton
+              color="contrast"
+              aria-label="Back to Dashboard"
+              onClick={props.handleGoBack}
+            >
+              <GoBackIcon />
+            </IconButton>
+          ) : (
+            <IconButton
+              color="contrast"
+              aria-label="Pick a Event"
+              onClick={props.handleOpenDrawer}
+            >
+              <MenuIcon />
+            </IconButton>
+          )}
           <Typography type="title" color="inherit" style={styles.title}>
             {props.title}
           </Typography>

--- a/src/wrapper/withNavigationBar.js
+++ b/src/wrapper/withNavigationBar.js
@@ -63,7 +63,7 @@ export const withNavigationBar = InnerComponent => {
           headers: {'X-Authorized-Token': token},
         })
         .then(response => {
-          const newEvents = response.data.event;
+          const newEvents = response.data.events;
           if (newEvents === undefined || newEvents.length <= 0) {
             this.setState({redirectToCreateEvent: true});
           } else {
@@ -96,6 +96,10 @@ export const withNavigationBar = InnerComponent => {
     handleOpenDrawer = () => {
       // TODO: Drawer描画コンポーネントの作成
       this.setState({openDrawer: true});
+    }
+
+    handleGoBack = () => {
+      this.props.history.goBack();
     }
 
     handleRequestCloseDrawer = () => {
@@ -138,7 +142,9 @@ export const withNavigationBar = InnerComponent => {
                 title={this.state.title}
                 handleSignOut={this.handleSignOut}
                 handleOpenDrawer={this.handleOpenDrawer}
+                handleGoBack={this.handleGoBack}
                 authorized={true}
+                goBack={this.props.location.pathname!=="/"}
               />
             </header>
             <div style={styles.content}>


### PR DESCRIPTION
rootパス（Dashboard）以外のlocationを開いている時、NavigationBarの左上を戻るボタンに変更し、押すことで1つ前の履歴に戻る機能を実装しました。