### PR TITLE
Fix getting events list from latest api

### DIFF
--- a/src/wrapper/withNavigationBar.js
+++ b/src/wrapper/withNavigationBar.js
@@ -63,7 +63,7 @@ export const withNavigationBar = InnerComponent => {
           headers: {'X-Authorized-Token': token},
         })
         .then(response => {
-          const newEvents = response.data.event;
+          const newEvents = response.data.events;
           if (newEvents === undefined || newEvents.length <= 0) {
             this.setState({redirectToCreateEvent: true});
           } else {


### PR DESCRIPTION
API側 GET [/events]が`event`から`events`に返すJSONのキーが変わったため