### PR TITLE
API の URL としてプリフィックス /api を追加

### DIFF
--- a/src/const/urls.js
+++ b/src/const/urls.js
@@ -21,8 +21,8 @@ const switchByEnv = values => {
 export const BASE_URI = switchByEnv({
   development: `http://localhost:3001`,
   test: `http://localhost:3001`,
-  production: `http://regi-urico.duckdns.org`,
-  default: `http://regi-urico.duckdns.org`
+  production: `http://regi-urico.duckdns.org/api`,
+  default: `http://regi-urico.duckdns.org/api`
 });
 
 export const CHANGE_ACCOUNT_URI = `/sellers/`;


### PR DESCRIPTION
ダッシュボードでリロードした時に`/`にリダイレクトを設定するために必要な修正です。