### PR TITLE
アカウント名の変更ページに現在のアカウント名をあらかじめ入力しておくように変更

### DIFF
--- a/src/AccountDashboard.js
+++ b/src/AccountDashboard.js
@@ -51,8 +51,9 @@ const styles = {
 class AccountDashboard extends Component {
   constructor(props) {
     super(props);
+    const name = localStorage.getItem('name') || '';
     this.state = {
-      name: '',
+      name: name,
       password: '',
       confirmDelete: '',
       redirectToRoot: false,
@@ -105,6 +106,7 @@ class AccountDashboard extends Component {
       .then(response => {
         if (response.status == 200) {
           // success to patch
+          localStorage.setItem('name', response.data.name);
           this.setState({
             name: response.data.name,
             openSnackbar: true,

--- a/src/LoginForm.js
+++ b/src/LoginForm.js
@@ -82,6 +82,7 @@ class LoginForm extends Component {
       })
       .then(response => {
         if (response.errors == null) {
+          localStorage.setItem('name', response.data.name);
           localStorage.setItem('authorizedToken', response.data.token);
           this.setState({redirectToDashboard: true});
         } else {


### PR DESCRIPTION
パスワードだけ変えたい場合でも名前まで変えてしまいそうだったので、現在の名前を表示するようにしました。
<img width="472" alt="2017-12-17 8 50 34" src="https://user-images.githubusercontent.com/1425259/34075393-0ccb2a96-e309-11e7-9669-03708b0d4c47.png">
